### PR TITLE
fix(mitthooks-drizzle): persist variantKey on update and upsert

### DIFF
--- a/packages/mitthooks-drizzle/src/pg/index.ts
+++ b/packages/mitthooks-drizzle/src/pg/index.ts
@@ -39,6 +39,7 @@ export class PgExtensionStorage implements ExtensionStorage {
                     active: true,
                     consentedScopes: extension.consentedScopes,
                     secret: extension.secret,
+                    variantKey: extension.variantKey ?? null,
                 })
                 .onConflictDoUpdate({
                     target: this.extensionInstanceTable.id,
@@ -48,6 +49,7 @@ export class PgExtensionStorage implements ExtensionStorage {
                         context: "project",
                         active: true,
                         secret: extension.secret,
+                        variantKey: extension.variantKey ?? null,
                     },
                 });
         } catch (error) {
@@ -68,6 +70,7 @@ export class PgExtensionStorage implements ExtensionStorage {
                     context: "project",
                     active: extension.enabled,
                     consentedScopes: extension.consentedScopes,
+                    variantKey: extension.variantKey ?? null,
                 })
                 .where(
                     eq(


### PR DESCRIPTION
## Summary

- Add `variantKey` to the `SET` clause in `PgExtensionStorage.updateExtension()`
- Add `variantKey` to `.values()` and `.onConflictDoUpdate().set()` in `PgExtensionStorage.upsertExtension()`

Without this fix, `InstanceUpdated` webhooks from mittwald do not persist the new `variantKey` to the database, even though the column exists in the schema and the type includes the field.

## Test plan

- [ ] Trigger an `InstanceUpdated` webhook and verify `variant_key` column is updated in the DB
- [ ] Trigger an `InstanceAdded` webhook and verify `variant_key` is set on initial insert
- [ ] Trigger an `InstanceAdded` webhook for an existing instance (upsert path) and verify `variant_key` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)