### PR TITLE
Fix sandcastle Docker build on macOS hosts (GID 20 collision)

### DIFF
--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -22,7 +22,18 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+# On macOS hosts, AGENT_GID is often 20 (staff), which collides with Debian's
+# `dialout` group; drop any pre-existing group/user at the target IDs first.
+RUN if getent group "$AGENT_GID" >/dev/null 2>&1; then \
+      EXISTING_GROUP="$(getent group "$AGENT_GID" | cut -d: -f1)"; \
+      if [ "$EXISTING_GROUP" != "node" ]; then groupdel "$EXISTING_GROUP"; fi; \
+    fi && \
+    if getent passwd "$AGENT_UID" >/dev/null 2>&1; then \
+      EXISTING_USER="$(getent passwd "$AGENT_UID" | cut -d: -f1)"; \
+      if [ "$EXISTING_USER" != "node" ]; then userdel "$EXISTING_USER"; fi; \
+    fi && \
+    groupmod -g "$AGENT_GID" node && \
+    usermod -u "$AGENT_UID" -g "$AGENT_GID" -d /home/agent -m -l agent node
 USER ${AGENT_UID}:${AGENT_GID}
 
 # Install Claude Code CLI


### PR DESCRIPTION
## Summary
- macOS users default to GID 20 (staff), which collides with Debian's `dialout` group, so `docker build` for this repo's sandcastle image failed with exit code 4 on macOS hosts.
- Drop any pre-existing group/user at the target IDs before renaming the base image's `node` user. Matches the fix already present in the orchestrator's root `.sandcastle/Dockerfile` and most other fleet repos.

## Test plan
- [ ] `pnpm sandcastle` succeeds from waldmeister on a macOS host (UID 501 / GID 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)