### PR TITLE
Sandcastle: pre-install pnpm via corepack in Dockerfile

### DIFF
--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -15,6 +15,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   && apt-get update && apt-get install -y gh \
   && rm -rf /var/lib/apt/lists/*
 
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable
+RUN corepack prepare pnpm@latest --activate
+
 # Build-args for UID/GID alignment: sandcastle docker build-image
 # defaults these to the host user's UID/GID so image-built files
 # and bind-mounted files share an owner without runtime chown.


### PR DESCRIPTION
Fixes #70

Generated by Sandcastle (waldmeister orchestrator).